### PR TITLE
Probot dco conf

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false


### PR DESCRIPTION

## Description

This adds the protobuf DCO-conf which lets an organization member skip signoff commits. We need to discuss what should be the default here.

## Type of change

- [ x] New feature (non-breaking change which adds functionality)
